### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ It features two methods of deployment:
 - **KCP**: The KCP-aware way to run the controllers against a KCP server.
 
 You can find the documentation for both deployment scenarios respectively:
-- [CAPI](./docs/capi/README.md)
-- [KCP](./docs/kcp/README.md)
+- [CAPI](./capi/README.md)
+- [KCP](./kcp/README.md)
 
 # [Testing 🧪](./testing.md)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

There were some broken links in the `docs/README.md` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
