### PR TITLE
Align `GardenerWorkerPool` behavior to `MachinePool` contract

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,11 +21,26 @@ rules:
   resources:
   - clusters
   - clusters/status
-  - machinepools
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools/status
+  verbs:
+  - get
+  - update
 - apiGroups:
   - controlplane.cluster.x-k8s.io
   resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

Apparently, we need to update the `MachinePool`s status to report the amount of ready nodes.
This way, the `MachinePool` changes it's status from `ScalingUp` to `Running` when ready.

> [!IMPORTANT]
> If you want to locally test this, you need to patch the `Shoot`s node to have a `.spec.providerID`.
> `MachinePool`s do not allow empty string `providerID`s, but our provider-local does not provide a `providerID`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
`MachinePool`s created with the `GardenerWorkerPool` will now report phase `Running` when all machines have been provisioned.
```
