### PR TITLE
Update module sigs.k8s.io/cluster-api to v1.10.3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,12 @@
   extends: [
     'github>gardener/gardener//.github/renovate.json5'
   ],
+  packageRules: [
+    {
+      matchPackageNames: ['sigs.k8s.io/cluster-api', 'kubernetes-sigs/cluster-api'],
+      groupName: 'sigs.k8s.io/cluster-api',
+    },
+  ],
   // The following list of dependencies to ignore is updated by `make generate`.
   // DO NOT EDIT THIS SECTION MANUALLY.
   ignoreDeps: [
@@ -165,6 +171,6 @@
     "sigs.k8s.io/json",
     "sigs.k8s.io/randfill",
     "sigs.k8s.io/structured-merge-diff/v4",
-    "sigs.k8s.io/yaml",
-  ],
+    "sigs.k8s.io/yaml"
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,7 @@
     "github.com/ahmetb/gen-crd-api-reference-docs",
     "github.com/onsi/ginkgo/v2",
     "github.com/onsi/gomega",
+    "golang.org/x/sync",
     "golang.org/x/tools",
     "k8s.io/api",
     "k8s.io/apimachinery",
@@ -137,7 +138,6 @@
     "golang.org/x/mod",
     "golang.org/x/net",
     "golang.org/x/oauth2",
-    "golang.org/x/sync",
     "golang.org/x/sys",
     "golang.org/x/term",
     "golang.org/x/text",
@@ -171,6 +171,6 @@
     "sigs.k8s.io/json",
     "sigs.k8s.io/randfill",
     "sigs.k8s.io/structured-merge-diff/v4",
-    "sigs.k8s.io/yaml"
+    "sigs.k8s.io/yaml",
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ ENVTEST_VERSION ?= v0.21.0
 # renovate: datasource=github-tags depName=kubernetes/api
 ENVTEST_K8S_VERSION ?= v0.33.2
 # renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
-CLUSTERCTL_VERSION ?= v1.9.9
+CLUSTERCTL_VERSION ?= v1.10.3
 # renovate: datasource=github-releases depName=kcp-dev/kcp
 APIGEN_VERSION ?= v0.27.1
 # renovate: datasource=github-releases depName=kcp-dev/kcp

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_gardenershootcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_gardenershootcontrolplanes.yaml
@@ -172,10 +172,11 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.24.0
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/gardener/gardener v1.121.4
+	github.com/kcp-dev/kcp/sdk v0.27.1
 	github.com/kcp-dev/multicluster-provider v0.1.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
+	golang.org/x/sync v0.15.0
 	golang.org/x/tools v0.34.0
 	k8s.io/api v0.32.5
 	k8s.io/apimachinery v0.32.5
@@ -15,7 +17,7 @@ require (
 	k8s.io/code-generator v0.32.5
 	k8s.io/component-base v0.32.5
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
-	sigs.k8s.io/cluster-api v1.9.9
+	sigs.k8s.io/cluster-api v1.10.3
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7
 )
@@ -80,7 +82,6 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3 // indirect
-	github.com/kcp-dev/kcp/sdk v0.27.1 // indirect
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
@@ -142,7 +143,6 @@ require (
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -699,8 +699,8 @@ k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.3 h1:PouPS/YVHiGXLJTXH/mtNybmnuSvjeh92wUkqIU4uCk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.9 h1:ZwrhTmIetan8Axceh+cuDbATrprntN6QmKRSQx7D5VU=
-sigs.k8s.io/cluster-api v1.9.9/go.mod h1:wii7FBtUW8x6nemHTpXlbmN73nN7M9k4weGcr/X0QBI=
+sigs.k8s.io/cluster-api v1.10.3 h1:7tE5xgQJutisgDyeLzaZ9JhDaHGuG3GjPltsFM89BoA=
+sigs.k8s.io/cluster-api v1.10.3/go.mod h1:pu1WDn+fdax9aC9ZtDDoXqnO7P3LLjxbKGU/Nzf/DF4=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/controller-tools v0.17.3 h1:lwFPLicpBKLgIepah+c8ikRBubFW5kOQyT88r3EwfNw=

--- a/schemas/gardener/apiresourceschema-clusters.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-clusters.cluster.x-k8s.io.yaml
@@ -55,11 +55,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterSpec defines the desired state of Cluster.
+            description: spec is the desired state of Cluster.
             properties:
               availabilityGates:
                 description: |-
                   availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                  If this field is not defined and the Cluster implements a managed topology, availabilityGates
+                  from the corresponding ClusterClass will be used, if any.
 
                   NOTE: this field is considered only for computing v1beta2 conditions.
                 items:
@@ -67,12 +70,23 @@ spec:
                   properties:
                     conditionType:
                       description: |-
-                        conditionType refers to a positive polarity condition (status true means good) with matching type in the Cluster's condition list.
+                        conditionType refers to a condition with matching type in the Cluster's condition list.
                         If the conditions doesn't exist, it will be treated as unknown.
                         Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
                       maxLength: 316
                       minLength: 1
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this availabilityGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                        - Positive
+                        - Negative
                       type: string
                   required:
                     - conditionType
@@ -83,7 +97,7 @@ spec:
                   - conditionType
                 x-kubernetes-list-type: map
               clusterNetwork:
-                description: Cluster network configuration.
+                description: clusterNetwork represents the cluster network configuration.
                 properties:
                   apiServerPort:
                     description: |-
@@ -92,24 +106,34 @@ spec:
                     format: int32
                     type: integer
                   pods:
-                    description: The network ranges from which Pod networks are allocated.
+                    description: pods is the network ranges from which Pod networks are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
+                          maxLength: 43
+                          minLength: 1
                           type: string
+                        maxItems: 100
                         type: array
                     required:
                       - cidrBlocks
                     type: object
                   serviceDomain:
-                    description: Domain name for services.
+                    description: serviceDomain is the domain name for services.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                   services:
-                    description: The network ranges from which service VIPs are allocated.
+                    description: services is the network ranges from which service VIPs are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
+                          maxLength: 43
+                          minLength: 1
                           type: string
+                        maxItems: 100
                         type: array
                     required:
                       - cidrBlocks
@@ -119,10 +143,11 @@ spec:
                 description: controlPlaneEndpoint represents the endpoint used to communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -224,22 +249,26 @@ spec:
                 type: boolean
               topology:
                 description: |-
-                  This encapsulates the topology for the cluster.
+                  topology encapsulates the topology for the cluster.
                   NOTE: It is required to enable the ClusterTopology
                   feature gate flag to activate managed topologies support;
                   this feature is highly experimental, and parts of it might still be not implemented.
                 properties:
                   class:
-                    description: The name of the ClusterClass object to create the topology.
+                    description: class is the name of the ClusterClass object to create the topology.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                   classNamespace:
                     description: |-
-                      classNamespace is the namespace of the ClusterClass object to create the topology.
-                      If the namespace is empty or not set, it is defaulted to the namespace of the cluster object.
-                      Value must follow the DNS1123Subdomain syntax.
-                    maxLength: 253
+                      classNamespace is the namespace of the ClusterClass that should be used for the topology.
+                      If classNamespace is empty or not set, it is defaulted to the namespace of the Cluster object.
+                      classNamespace must be a valid namespace name and because of that be at most 63 characters in length
+                      and it must consist only of lower case alphanumeric characters or hyphens (-), and must start
+                      and end with an alphanumeric character.
+                    maxLength: 63
                     minLength: 1
-                    pattern: ^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   controlPlane:
                     description: controlPlane describes the cluster control plane.
@@ -266,7 +295,8 @@ spec:
                               - type: integer
                               - type: string
                             description: |-
-                              Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                              maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                              Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                               "selector" are not healthy.
                             x-kubernetes-int-or-string: true
                           nodeStartupTimeout:
@@ -345,11 +375,18 @@ spec:
                                 status for at least the timeout value, a node is considered unhealthy.
                               properties:
                                 status:
+                                  description: status of the condition, one of True, False, Unknown.
                                   minLength: 1
                                   type: string
                                 timeout:
+                                  description: |-
+                                    timeout is the duration that a node must be in a given status for,
+                                    after which the node is considered unhealthy.
+                                    For example, with a value of "1h", the node must match the status
+                                    for at least 1 hour before being considered unhealthy.
                                   type: string
                                 type:
+                                  description: type of Node condition
                                   minLength: 1
                                   type: string
                               required:
@@ -357,14 +394,18 @@ spec:
                                 - timeout
                                 - type
                               type: object
+                            maxItems: 100
                             type: array
                           unhealthyRange:
                             description: |-
+                              unhealthyRange specifies the range of unhealthy machines allowed.
                               Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                              is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                              is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                               Eg. "[3-5]" - This means that remediation will be allowed only when:
                               (a) there are at least 3 unhealthy machines (and)
                               (b) there are at most 5 unhealthy machines
+                            maxLength: 32
+                            minLength: 1
                             pattern: ^\[[0-9]+-[0-9]+\]$
                             type: string
                         type: object
@@ -388,7 +429,7 @@ spec:
                             additionalProperties:
                               type: string
                             description: |-
-                              Map of string keys and values that can be used to organize and categorize
+                              labels is a map of string keys and values that can be used to organize and categorize
                               (scope and select) objects. May match selectors of replication controllers
                               and services.
                               More info: http://kubernetes.io/docs/user-guide/labels
@@ -411,6 +452,49 @@ spec:
                           nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                           to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
                         type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                          computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                          If this field is not defined, readinessGates from the corresponding ControlPlaneClass will be used, if any.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
+                          e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+                        items:
+                          description: MachineReadinessGate contains the type of a Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                                - Positive
+                                - Negative
+                              type: string
+                          required:
+                            - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - conditionType
+                        x-kubernetes-list-type: map
                       replicas:
                         description: |-
                           replicas is the number of control plane nodes.
@@ -434,9 +518,12 @@ spec:
                                     definitionFrom specifies where the definition of this Variable is from.
 
                                     Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                  maxLength: 256
                                   type: string
                                 name:
                                   description: name of the variable.
+                                  maxLength: 256
+                                  minLength: 1
                                   type: string
                                 value:
                                   description: |-
@@ -452,6 +539,7 @@ spec:
                                 - name
                                 - value
                               type: object
+                            maxItems: 1000
                             type: array
                             x-kubernetes-list-map-keys:
                               - name
@@ -481,9 +569,12 @@ spec:
                             definitionFrom specifies where the definition of this Variable is from.
 
                             Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                          maxLength: 256
                           type: string
                         name:
                           description: name of the variable.
+                          maxLength: 256
+                          minLength: 1
                           type: string
                         value:
                           description: |-
@@ -499,12 +590,15 @@ spec:
                         - name
                         - value
                       type: object
+                    maxItems: 1000
                     type: array
                     x-kubernetes-list-map-keys:
                       - name
                     x-kubernetes-list-type: map
                   version:
-                    description: The Kubernetes version of the cluster.
+                    description: version is the Kubernetes version of the cluster.
+                    maxLength: 256
+                    minLength: 1
                     type: string
                   workers:
                     description: |-
@@ -523,11 +617,15 @@ spec:
                                 class is the name of the MachineDeploymentClass used to create the set of worker nodes.
                                 This should match one of the deployment classes defined in the ClusterClass object
                                 mentioned in the `Cluster.Spec.Class` field.
+                              maxLength: 256
+                              minLength: 1
                               type: string
                             failureDomain:
                               description: |-
                                 failureDomain is the failure domain the machines will be created in.
                                 Must match a key in the FailureDomains map stored on the cluster object.
+                              maxLength: 256
+                              minLength: 1
                               type: string
                             machineHealthCheck:
                               description: |-
@@ -551,7 +649,8 @@ spec:
                                     - type: integer
                                     - type: string
                                   description: |-
-                                    Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                                    maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                    Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                                     "selector" are not healthy.
                                   x-kubernetes-int-or-string: true
                                 nodeStartupTimeout:
@@ -630,11 +729,18 @@ spec:
                                       status for at least the timeout value, a node is considered unhealthy.
                                     properties:
                                       status:
+                                        description: status of the condition, one of True, False, Unknown.
                                         minLength: 1
                                         type: string
                                       timeout:
+                                        description: |-
+                                          timeout is the duration that a node must be in a given status for,
+                                          after which the node is considered unhealthy.
+                                          For example, with a value of "1h", the node must match the status
+                                          for at least 1 hour before being considered unhealthy.
                                         type: string
                                       type:
+                                        description: type of Node condition
                                         minLength: 1
                                         type: string
                                     required:
@@ -642,14 +748,18 @@ spec:
                                       - timeout
                                       - type
                                     type: object
+                                  maxItems: 100
                                   type: array
                                 unhealthyRange:
                                   description: |-
+                                    unhealthyRange specifies the range of unhealthy machines allowed.
                                     Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                                    is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                                    is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                                     Eg. "[3-5]" - This means that remediation will be allowed only when:
                                     (a) there are at least 3 unhealthy machines (and)
                                     (b) there are at most 5 unhealthy machines
+                                  maxLength: 32
+                                  minLength: 1
                                   pattern: ^\[[0-9]+-[0-9]+\]$
                                   type: string
                               type: object
@@ -671,7 +781,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Map of string keys and values that can be used to organize and categorize
+                                    labels is a map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -679,7 +789,7 @@ spec:
                               type: object
                             minReadySeconds:
                               description: |-
-                                Minimum number of seconds for which a newly created machine should
+                                minReadySeconds is the minimum number of seconds for which a newly created machine should
                                 be ready.
                                 Defaults to 0 (machine will be considered available as soon as it
                                 is ready)
@@ -691,6 +801,8 @@ spec:
                                 The value is used with other unique identifiers to create a MachineDeployment's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
+                              maxLength: 63
+                              minLength: 1
                               type: string
                             nodeDeletionTimeout:
                               description: |-
@@ -709,6 +821,47 @@ spec:
                                 nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                                 to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
                               type: string
+                            readinessGates:
+                              description: |-
+                                readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                                This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                                computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                                If this field is not defined, readinessGates from the corresponding MachineDeploymentClass will be used, if any.
+
+                                NOTE: This field is considered only for computing v1beta2 conditions.
+                              items:
+                                description: MachineReadinessGate contains the type of a Machine condition to be used as a readiness gate.
+                                properties:
+                                  conditionType:
+                                    description: |-
+                                      conditionType refers to a condition with matching type in the Machine's condition list.
+                                      If the conditions doesn't exist, it will be treated as unknown.
+                                      Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                                    maxLength: 316
+                                    minLength: 1
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                  polarity:
+                                    description: |-
+                                      polarity of the conditionType specified in this readinessGate.
+                                      Valid values are Positive, Negative and omitted.
+                                      When omitted, the default behaviour will be Positive.
+                                      A positive polarity means that the condition should report a true status under normal conditions.
+                                      A negative polarity means that the condition should report a false status under normal conditions.
+                                    enum:
+                                      - Positive
+                                      - Negative
+                                    type: string
+                                required:
+                                  - conditionType
+                                type: object
+                              maxItems: 32
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - conditionType
+                              x-kubernetes-list-type: map
                             replicas:
                               description: |-
                                 replicas is the number of worker nodes belonging to this set.
@@ -719,7 +872,7 @@ spec:
                               type: integer
                             strategy:
                               description: |-
-                                The deployment strategy to use to replace existing machines with
+                                strategy is the deployment strategy to use to replace existing machines with
                                 new ones.
                               properties:
                                 remediation:
@@ -750,7 +903,7 @@ spec:
                                   type: object
                                 rollingUpdate:
                                   description: |-
-                                    Rolling update config params. Present only if
+                                    rollingUpdate is the rolling update config params. Present only if
                                     MachineDeploymentStrategyType = RollingUpdate.
                                   properties:
                                     deletePolicy:
@@ -768,7 +921,7 @@ spec:
                                         - type: integer
                                         - type: string
                                       description: |-
-                                        The maximum number of machines that can be scheduled above the
+                                        maxSurge is the maximum number of machines that can be scheduled above the
                                         desired number of machines.
                                         Value can be an absolute number (ex: 5) or a percentage of
                                         desired machines (ex: 10%).
@@ -787,7 +940,7 @@ spec:
                                         - type: integer
                                         - type: string
                                       description: |-
-                                        The maximum number of machines that can be unavailable during the update.
+                                        maxUnavailable is the maximum number of machines that can be unavailable during the update.
                                         Value can be an absolute number (ex: 5) or a percentage of desired
                                         machines (ex: 10%).
                                         Absolute number is calculated from percentage by rounding down.
@@ -825,9 +978,12 @@ spec:
                                           definitionFrom specifies where the definition of this Variable is from.
 
                                           Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        maxLength: 256
                                         type: string
                                       name:
                                         description: name of the variable.
+                                        maxLength: 256
+                                        minLength: 1
                                         type: string
                                       value:
                                         description: |-
@@ -843,6 +999,7 @@ spec:
                                       - name
                                       - value
                                     type: object
+                                  maxItems: 1000
                                   type: array
                                   x-kubernetes-list-map-keys:
                                     - name
@@ -852,6 +1009,7 @@ spec:
                             - class
                             - name
                           type: object
+                        maxItems: 2000
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -868,13 +1026,18 @@ spec:
                                 class is the name of the MachinePoolClass used to create the pool of worker nodes.
                                 This should match one of the deployment classes defined in the ClusterClass object
                                 mentioned in the `Cluster.Spec.Class` field.
+                              maxLength: 256
+                              minLength: 1
                               type: string
                             failureDomains:
                               description: |-
                                 failureDomains is the list of failure domains the machine pool will be created in.
                                 Must match a key in the FailureDomains map stored on the cluster object.
                               items:
+                                maxLength: 256
+                                minLength: 1
                                 type: string
+                              maxItems: 100
                               type: array
                             metadata:
                               description: |-
@@ -894,7 +1057,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Map of string keys and values that can be used to organize and categorize
+                                    labels is a map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -902,7 +1065,7 @@ spec:
                               type: object
                             minReadySeconds:
                               description: |-
-                                Minimum number of seconds for which a newly created machine pool should
+                                minReadySeconds is the minimum number of seconds for which a newly created machine pool should
                                 be ready.
                                 Defaults to 0 (machine will be considered available as soon as it
                                 is ready)
@@ -914,6 +1077,8 @@ spec:
                                 The value is used with other unique identifiers to create a MachinePool's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
+                              maxLength: 63
+                              minLength: 1
                               type: string
                             nodeDeletionTimeout:
                               description: |-
@@ -955,9 +1120,12 @@ spec:
                                           definitionFrom specifies where the definition of this Variable is from.
 
                                           Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        maxLength: 256
                                         type: string
                                       name:
                                         description: name of the variable.
+                                        maxLength: 256
+                                        minLength: 1
                                         type: string
                                       value:
                                         description: |-
@@ -973,6 +1141,7 @@ spec:
                                       - name
                                       - value
                                     type: object
+                                  maxItems: 1000
                                   type: array
                                   x-kubernetes-list-map-keys:
                                     - name
@@ -982,6 +1151,7 @@ spec:
                             - class
                             - name
                           type: object
+                        maxItems: 2000
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -993,7 +1163,7 @@ spec:
                 type: object
             type: object
           status:
-            description: ClusterStatus defines the observed state of Cluster.
+            description: status is the observed state of Cluster.
             properties:
               conditions:
                 description: conditions defines current service state of the cluster.
@@ -1002,27 +1172,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -1032,6 +1207,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                     - lastTransitionTime
@@ -1070,6 +1247,8 @@ spec:
                   state, and will be set to a descriptive error message.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
                 type: string
               failureReason:
                 description: |-
@@ -1087,9 +1266,14 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: |-
-                  phase represents the current phase of cluster actuation.
-                  E.g. Pending, Running, Terminating, Failed etc.
+                description: phase represents the current phase of cluster actuation.
+                enum:
+                  - Pending
+                  - Provisioning
+                  - Provisioned
+                  - Deleting
+                  - Failed
+                  - Unknown
                 type: string
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified in Cluster's status with the V1Beta2 version.

--- a/schemas/gardener/apiresourceschema-gardenershootcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-gardenershootcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -155,10 +155,11 @@ spec:
                 description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:

--- a/schemas/gardener/apiresourceschema-machinepools.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-machinepools.cluster.x-k8s.io.yaml
@@ -64,20 +64,24 @@ spec:
           metadata:
             type: object
           spec:
-            description: MachinePoolSpec defines the desired state of MachinePool.
+            description: spec is the desired state of MachinePool.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs to.
+                maxLength: 63
                 minLength: 1
                 type: string
               failureDomains:
                 description: failureDomains is the list of failure domains this MachinePool should be attached to.
                 items:
+                  maxLength: 256
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               minReadySeconds:
                 description: |-
-                  Minimum number of seconds for which a newly created machine instances should
+                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
                   be ready.
                   Defaults to 0 (machine instance will be considered available as soon as it
                   is ready)
@@ -88,11 +92,14 @@ spec:
                   providerIDList are the identification IDs of machine instances provided by the provider.
                   This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
+                  maxLength: 512
+                  minLength: 1
                   type: string
+                maxItems: 10000
                 type: array
               replicas:
                 description: |-
-                  Number of desired machines. Defaults to 1.
+                  replicas is the number of desired machines. Defaults to 1.
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
@@ -101,7 +108,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -117,7 +124,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          Map of string keys and values that can be used to organize and categorize
+                          labels is a map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -125,7 +132,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      Specification of the desired behavior of the machine.
+                      spec is the specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -184,16 +191,21 @@ spec:
                             description: |-
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:
                         description: clusterName is the name of the Cluster this object belongs to.
+                        maxLength: 63
                         minLength: 1
                         type: string
                       failureDomain:
                         description: |-
                           failureDomain is the failure domain the machine will be created in.
                           Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
                         type: string
                       infrastructureRef:
                         description: |-
@@ -269,6 +281,8 @@ spec:
                           and then a comparison is done to find out unregistered machines and are marked for delete.
                           This field will be set by the actuators and consumed by higher level entities like autoscaler that will
                           be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
                         type: string
                       readinessGates:
                         description: |-
@@ -291,12 +305,23 @@ spec:
                           properties:
                             conditionType:
                               description: |-
-                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
+                                conditionType refers to a condition with matching type in the Machine's condition list.
                                 If the conditions doesn't exist, it will be treated as unknown.
                                 Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
                               maxLength: 316
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                                - Positive
+                                - Negative
                               type: string
                           required:
                             - conditionType
@@ -310,6 +335,8 @@ spec:
                         description: |-
                           version defines the desired Kubernetes version.
                           This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
                         type: string
                     required:
                       - bootstrap
@@ -322,10 +349,10 @@ spec:
               - template
             type: object
           status:
-            description: MachinePoolStatus defines the observed state of MachinePool.
+            description: status is the observed state of MachinePool.
             properties:
               availableReplicas:
-                description: The number of available replicas (ready for at least minReadySeconds) for this MachinePool.
+                description: availableReplicas is the number of available replicas (ready for at least minReadySeconds) for this MachinePool.
                 format: int32
                 type: integer
               bootstrapReady:
@@ -338,27 +365,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -368,6 +400,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                     - lastTransitionTime
@@ -381,6 +415,8 @@ spec:
                   and will be set to a descriptive error message.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
                 type: string
               failureReason:
                 description: |-
@@ -437,18 +473,28 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                maxItems: 10000
                 type: array
               observedGeneration:
                 description: observedGeneration is the latest generation observed by the controller.
                 format: int64
                 type: integer
               phase:
-                description: |-
-                  phase represents the current phase of cluster actuation.
-                  E.g. Pending, Running, Terminating, Failed etc.
+                description: phase represents the current phase of cluster actuation.
+                enum:
+                  - Pending
+                  - Provisioning
+                  - Provisioned
+                  - Running
+                  - ScalingUp
+                  - ScalingDown
+                  - Scaling
+                  - Deleting
+                  - Failed
+                  - Unknown
                 type: string
               readyReplicas:
-                description: The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
+                description: readyReplicas is the number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -457,7 +503,7 @@ spec:
                 type: integer
               unavailableReplicas:
                 description: |-
-                  Total number of unavailable machine instances targeted by this machine pool.
+                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
                   This is the total number of machine instances that are still required for
                   the machine pool to have 100% available capacity. They may either
                   be machine instances that are running but not yet available or machine instances


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Replaces:
- https://github.com/gardener/cluster-api-provider-gardener/pull/29
- https://github.com/gardener/cluster-api-provider-gardener/pull/19

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @tobschli

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
