### PR TITLE
Add `kind-kcp` e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,14 +293,16 @@ $(KCP): $(LOCALBIN)
 kubectl-kcp: $(KUBECTL_KCP) ## Download kubectl-kcp locally if necessary.
 $(KUBECTL_KCP): $(LOCALBIN)
 	curl -Lo $(KUBECTL_KCP).tar.gz https://github.com/kcp-dev/kcp/releases/download/$(KCP_VERSION)/kubectl-kcp-plugin_$(KCP_VERSION:v%=%)_$(SYSTEM_NAME)_$(SYSTEM_ARCH).tar.gz
-	tar -zxvf $(KUBECTL_KCP).tar.gz bin/kubectl-kcp
+	tar -zxvf $(KUBECTL_KCP).tar.gz bin/
+	rm $(KUBECTL_KCP).tar.gz
 	touch $(KUBECTL_KCP) && chmod +x $(KUBECTL_KCP)
 
 .PHONY: kubectl-ws
 kubectl-ws: $(KUBECTL_WS) ## Download kubectl-kcp locally if necessary.
 $(KUBECTL_WS): $(LOCALBIN)
 	curl -Lo $(KUBECTL_WS).tar.gz https://github.com/kcp-dev/kcp/releases/download/$(KCP_VERSION)/kubectl-create-workspace-plugin_$(KCP_VERSION:v%=%)_$(SYSTEM_NAME)_$(SYSTEM_ARCH).tar.gz
-	tar -zxvf $(KUBECTL_WS).tar.gz bin/kubectl-create-workspace
+	tar -zxvf $(KUBECTL_WS).tar.gz bin/
+	rm $(KUBECTL_WS).tar.gz
 	touch $(KUBECTL_WS) && chmod +x $(KUBECTL_WS)
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test-e2e: $(KIND) ## Run the e2e tests. Expected an isolated environment using K
 		echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
 		exit 1; \
 	}
-	KUBECONFIG=$(GARDENER_KUBECONFIG) CERT_MANAGER_INSTALL_SKIP=true go test ./test/e2e/ -v -ginkgo.v
+	KUBECONFIG=$(GARDENER_KUBECONFIG) CERT_MANAGER_INSTALL_SKIP=true go test ./test/e2e/... -v -ginkgo.v # --ginkgo.label-filter=kind-kcp
 
 .PHONY: kcp-up
 kcp-up: kcp
@@ -126,7 +126,7 @@ clusterctl-init: clusterctl
 	KUBECONFIG=$(GARDENER_KUBECONFIG) EXP_MACHINE_POOL=true $(CLUSTERCTL) init
 
 .PHONY: ci-e2e-kind
-ci-e2e-kind: kind-gardener-up clusterctl-init test-e2e
+ci-e2e-kind: kind-gardener-up test-e2e
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER) ## Format imports.

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ clusterctl-init: clusterctl
 	KUBECONFIG=$(GARDENER_KUBECONFIG) EXP_MACHINE_POOL=true $(CLUSTERCTL) init
 
 .PHONY: ci-e2e-kind
-ci-e2e-kind: kind-gardener-up test-e2e
+ci-e2e-kind: kubectl-ws kubectl-kcp kind-gardener-up test-e2e
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER) ## Format imports.

--- a/docs/kcp/getting-started-locally.md
+++ b/docs/kcp/getting-started-locally.md
@@ -33,7 +33,7 @@ kubectl apply -f schemas/binding.yaml
 
 **Run controller:**
 ```shell
-ENABLE_WEBHOOKS=false go run cmd/main.go --kubeconfig <path/to/kcp-kubeconfig> -gardener-kubeconfig  <path/to/gardener/kubeconfig.yaml>
+ENABLE_WEBHOOKS=false go run cmd/main.go --kubeconfig <path/to/kcp-kubeconfig> -gardener-kubeconfig <path/to/gardener/kubeconfig.yaml>
 ```
 
 **Create and enter consuming workspace:**

--- a/test/e2e/kind-kcp/e2e_suite_test.go
+++ b/test/e2e/kind-kcp/e2e_suite_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kind_kcp
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/cluster-api-provider-gardener/test/utils"
+)
+
+// TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
+// temporary environment to validate project changes with the the purposed to be used in CI jobs.
+// The default setup requires Kind, builds/loads the Manager Docker image locally, and installs
+// CertManager.
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter)))
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting cluster-api-provider-gardener e2e test suite\n")
+	RunSpecs(t, "e2e suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(os.Setenv("KCP_PORT", "6444")).To(Succeed())
+	Expect(os.Setenv("KUBECONFIG", kubeconfigKcp)).To(Succeed())
+
+	By("running kcp")
+	go func() {
+		defer GinkgoRecover()
+
+		cmd := exec.Command("make", "kcp-up")
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to run kcp")
+	}()
+
+	By("ensuring provider workspace")
+	Eventually(func() error {
+		return utils.EnsureAndSwitchWorkspace("gardener")
+	}).To(Succeed())
+
+	By("duplicate kubeconfig")
+	cmd := exec.Command("cp", kubeconfigKcp, kubeconfigKcpWorkload)
+	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to duplicate kubeconfig")
+})

--- a/test/e2e/kind-kcp/e2e_test.go
+++ b/test/e2e/kind-kcp/e2e_test.go
@@ -38,9 +38,6 @@ var (
 )
 
 var _ = Describe("Manager", Ordered, Label("kind-kcp"), func() {
-	// Before running the tests, set up the environment by creating the namespace,
-	// enforce the restricted security policy to the namespace, installing CRDs,
-	// and deploying the controller.
 	BeforeAll(func() {
 		By("installing APIResourceSchemas, APIExports and APIBindings in the provider workspace")
 		Eventually(func(g Gomega) {
@@ -99,7 +96,7 @@ var _ = Describe("Manager", Ordered, Label("kind-kcp"), func() {
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create APIBindings in the consuming workspace")
 		})
-		It("should create a GardenerShootControlPlane with a hibernated Shoot", func(ctx SpecContext) {
+		It("should create a CAPI Cluster resulting in a hibernated Shoot", func(ctx SpecContext) {
 			By("create client")
 
 			kcpClient, err := kubernetes.NewClientFromFile("", kubeconfigKcpWorkload,

--- a/test/e2e/kind-kcp/e2e_test.go
+++ b/test/e2e/kind-kcp/e2e_test.go
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kind_kcp
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	gardenercorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/cluster-api-provider-gardener/api"
+	controlplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/controlplane/v1alpha1"
+	infrastructurev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/infrastructure/v1alpha1"
+	"github.com/gardener/cluster-api-provider-gardener/test/utils"
+)
+
+// namespace where the project is deployed in
+const namespace = "gardener"
+
+var (
+	kubeconfigKcp         = ".kcp/admin.kubeconfig"
+	kubeconfigKcpWorkload = ".kcp/workload.kubeconfig"
+	kubeconfigGardener    = "./bin/gardener/example/provider-local/seed-kind/base/kubeconfig"
+)
+
+var _ = Describe("Manager", Ordered, Label("kind-kcp"), func() {
+	// Before running the tests, set up the environment by creating the namespace,
+	// enforce the restricted security policy to the namespace, installing CRDs,
+	// and deploying the controller.
+	BeforeAll(func() {
+		By("installing APIResourceSchemas, APIExports and APIBindings in the provider workspace")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "apply", "-f", "schemas/gardener")
+			output, err := utils.Run(cmd)
+			_, _ = fmt.Fprintf(GinkgoWriter, "Output:\n %s", output)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to install APIResourceSchemas, APIExports")
+		}).Should(Succeed())
+
+		cmd := exec.Command("kubectl", "apply", "-f", "schemas/binding.yaml")
+		output, err := utils.Run(cmd)
+		_, _ = fmt.Fprintf(GinkgoWriter, "Output:\n %s", output)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install APIBindings")
+
+		go func() {
+			defer GinkgoRecover()
+
+			By("running the controller")
+			Expect(os.Setenv("ENABLE_WEBHOOKS", "false")).To(Succeed())
+			cmd = exec.Command("go", "run", "cmd/main.go", "--kubeconfig", kubeconfigKcp, "-gardener-kubeconfig", kubeconfigGardener)
+			controllerOutput, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to run the controller")
+			_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerOutput)
+		}()
+	})
+
+	// After each test, check for failures and collect logs, events,
+	// and pod descriptions for debugging.
+	AfterEach(func() {
+		specReport := CurrentSpecReport()
+		if specReport.Failed() {
+			By("Fetching Kubernetes events")
+			cmd := exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+			eventsOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
+			}
+		}
+	})
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	Context("Manager", func() {
+		BeforeAll(func() {
+			Expect(os.Setenv("KUBECONFIG", kubeconfigKcpWorkload)).To(Succeed())
+			By("Switch to kcp consuming workload workspace")
+			Eventually(func() error {
+				return utils.EnsureAndSwitchWorkspace("gardener", "test")
+			}).To(Succeed())
+
+			By("Create APIBindings in the consuming workspace")
+			cmd := exec.Command("kubectl", "apply", "-f", "schemas/binding.yaml")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create APIBindings in the consuming workspace")
+		})
+		It("should create a GardenerShootControlPlane with a hibernated Shoot", func(ctx SpecContext) {
+			By("create client")
+
+			kcpClient, err := kubernetes.NewClientFromFile("", kubeconfigKcpWorkload,
+				kubernetes.WithClientOptions(client.Options{Scheme: api.Scheme}),
+				kubernetes.WithClientConnectionOptions(
+					componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
+				kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
+				kubernetes.WithDisabledCachedClient(),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			gardenerClient, err := kubernetes.NewClientFromFile("", kubeconfigGardener,
+				kubernetes.WithClientOptions(client.Options{Scheme: api.Scheme}),
+				kubernetes.WithClientConnectionOptions(
+					componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
+				kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
+				kubernetes.WithDisabledCachedClient(),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			namePrefix := "e2e-kcp-"
+
+			controlPlaneSpec := &controlplanev1alpha1.GardenerShootControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: namePrefix,
+					Namespace:    "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "cluster-api-provider-gardener",
+						"app.kubernetes.io/managed-by": "kustomize",
+					},
+				},
+				Spec: controlplanev1alpha1.GardenerShootControlPlaneSpec{
+					ProjectNamespace: "garden-local",
+					Provider:         controlplanev1alpha1.ProviderGSCP{Type: "local"},
+					Kubernetes:       gardenercorev1beta1.Kubernetes{Version: "1.32"},
+					CloudProfile:     &gardenercorev1beta1.CloudProfileReference{Name: "local"},
+					Workerless:       true,
+				},
+			}
+
+			By("create control plane")
+			Eventually(func() error {
+				return kcpClient.Client().Create(ctx, controlPlaneSpec)
+			}).Should(Succeed())
+
+			infraClusterSpec := &infrastructurev1alpha1.GardenerShootCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: namePrefix,
+					Namespace:    "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "cluster-api-provider-gardener",
+						"app.kubernetes.io/managed-by": "kustomize",
+					},
+				},
+				Spec: infrastructurev1alpha1.GardenerShootClusterSpec{
+					Region:      "local",
+					Hibernation: &gardenercorev1beta1.Hibernation{Enabled: ptr.To(true)},
+				},
+			}
+
+			By("create infra cluster")
+			Eventually(func() error {
+				return kcpClient.Client().Create(ctx, infraClusterSpec)
+			}).Should(Succeed())
+
+			clusterSpec := &v1beta1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: controlPlaneSpec.Name, Namespace: "default"},
+				Spec: v1beta1.ClusterSpec{
+					ControlPlaneRef: &v1.ObjectReference{
+						APIVersion: "controlplane.cluster.x-k8s.io/v1alpha1",
+						Kind:       "GardenerShootControlPlane",
+						Name:       controlPlaneSpec.Name,
+						Namespace:  "default",
+					},
+					InfrastructureRef: &v1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha1",
+						Kind:       "GardenerShootCluster",
+						Name:       infraClusterSpec.Name,
+						Namespace:  "default",
+					},
+				},
+			}
+
+			By("create cluster")
+			Expect(kcpClient.Client().Create(ctx, clusterSpec)).To(Succeed())
+
+			shoot := &gardenercorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{Name: controlPlaneSpec.Name, Namespace: "garden-local"},
+			}
+
+			By(fmt.Sprintf("Ensure shoot is synced to gardener cluster (Name: %s)", controlPlaneSpec.Name))
+			Eventually(func(g Gomega) {
+				g.Expect(gardenerClient.Client().Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				g.Expect(shoot.Status.LastOperation).ToNot(BeNil())
+			}).WithTimeout(30 * time.Second).Should(Succeed())
+
+			By(fmt.Sprintf("Ensure control plane is reconciled and shoot is created (Name: %s)", controlPlaneSpec.Name))
+			Eventually(func(g Gomega) {
+				g.Expect(gardenerClient.Client().Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				g.Expect(shoot.Status.LastOperation).ToNot(BeNil())
+				g.Expect(shoot.Status.LastOperation.Progress).To(BeEquivalentTo(100))
+				g.Expect(shoot.Status.LastOperation.State).To(Equal(gardenercorev1beta1.LastOperationStateSucceeded))
+			}).WithTimeout(10 * time.Minute).Should(Succeed())
+
+			By("Ensure control plane spec is updated from shoot")
+			Expect(kcpClient.Client().Get(ctx, client.ObjectKeyFromObject(controlPlaneSpec), controlPlaneSpec)).To(Succeed())
+
+			By("Deleting cluster")
+			Expect(kcpClient.Client().Delete(ctx, clusterSpec)).To(Succeed())
+
+			By("Ensure shoot receives delete request")
+			Eventually(func(g Gomega) {
+				g.Expect(gardenerClient.Client().Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				g.Expect(shoot.DeletionTimestamp).ToNot(BeNil())
+			}).Should(Succeed())
+
+			By("Ensure control plane is deleted")
+			Eventually(func() error {
+				return kcpClient.Client().Get(ctx, client.ObjectKeyFromObject(controlPlaneSpec), controlPlaneSpec)
+			}).WithTimeout(10 * time.Minute).Should(matchers.BeNotFoundError())
+
+			By("Ensure cluster object is deleted")
+			Eventually(func() error {
+				return kcpClient.Client().Get(ctx, client.ObjectKeyFromObject(controlPlaneSpec), controlPlaneSpec)
+			}).Should(matchers.BeNotFoundError())
+		})
+	})
+})

--- a/test/e2e/kind/e2e_suite_test.go
+++ b/test/e2e/kind/e2e_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kind
 
 import (
 	"fmt"
@@ -39,14 +39,19 @@ var (
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter)))
-	_, _ = fmt.Fprintf(GinkgoWriter, "Starting cluster-api-provider-gardener integration test suite\n")
-	RunSpecs(t, "e2e suite")
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting cluster-api-provider-gardener e2e test suite\n")
+	RunSpecs(t, "e2e suite kind")
 }
 
 var _ = BeforeSuite(func() {
-	By("building the manager(Operator) image")
-	cmd := exec.Command("make", "docker-build", "docker-push", fmt.Sprintf("IMG=%s", projectImage))
+	By("Initializing cluster-api")
+	cmd := exec.Command("make", "clusterctl-init")
 	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to initialize cluster-api")
+
+	By("building the manager(Operator) image")
+	cmd = exec.Command("make", "docker-build", "docker-push", fmt.Sprintf("IMG=%s", projectImage))
+	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build and push the manager(Operator) image")
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.

--- a/test/e2e/kind/e2e_test.go
+++ b/test/e2e/kind/e2e_test.go
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package kind
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	gardenercorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -30,19 +28,12 @@ import (
 	"github.com/gardener/cluster-api-provider-gardener/test/utils"
 )
 
-// namespace where the project is deployed in
-const namespace = "cluster-api-provider-gardener-system"
+const (
+	// namespace where the project is deployed in
+	namespace = "cluster-api-provider-gardener-system"
+)
 
-// serviceAccountName created for the project
-const serviceAccountName = "cluster-api-provider-gardener-controller-manager"
-
-// metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "cluster-api-provider-gardener-controller-manager-metrics-service"
-
-// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "cluster-api-provider-gardener-metrics-binding"
-
-var _ = Describe("Manager", Ordered, func() {
+var _ = Describe("Manager", Ordered, Label("kind"), func() {
 	var controllerPodName string
 
 	// Before running the tests, set up the environment by creating the namespace,
@@ -170,92 +161,6 @@ var _ = Describe("Manager", Ordered, func() {
 			Eventually(verifyControllerUp).Should(Succeed())
 		})
 
-		XIt("should ensure the metrics endpoint is serving metrics", func() {
-			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=cluster-api-provider-gardener-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
-
-			By("validating that the metrics service is available")
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
-
-			By("getting the service account token")
-			token, err := serviceAccountToken()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(token).NotTo(BeEmpty())
-
-			By("waiting for the metrics endpoint to be ready")
-			verifyMetricsEndpointReady := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
-			}
-			Eventually(verifyMetricsEndpointReady).Should(Succeed())
-
-			By("verifying that the controller manager is serving the metrics server")
-			verifyMetricsServerStarted := func(g Gomega) {
-				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
-					"Metrics server not yet started")
-			}
-			Eventually(verifyMetricsServerStarted).Should(Succeed())
-
-			By("creating the curl-metrics pod to access the metrics endpoint")
-			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
-				"--overrides",
-				fmt.Sprintf(`{
-					"spec": {
-						"containers": [{
-							"name": "curl",
-							"image": "curlimages/curl:latest",
-							"command": ["/bin/sh", "-c"],
-							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
-							"securityContext": {
-								"allowPrivilegeEscalation": false,
-								"capabilities": {
-									"drop": ["ALL"]
-								},
-								"runAsNonRoot": true,
-								"runAsUser": 1000,
-								"seccompProfile": {
-									"type": "RuntimeDefault"
-								}
-							}
-						}],
-						"serviceAccount": "%s"
-					}
-				}`, token, metricsServiceName, namespace, serviceAccountName))
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
-
-			By("waiting for the curl-metrics pod to complete.")
-			verifyCurlUp := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
-					"-o", "jsonpath={.status.phase}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
-			}
-			Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
-
-			By("getting the metrics by checking curl-metrics logs")
-			metricsOutput := getMetricsOutput()
-			Expect(metricsOutput).To(ContainSubstring(
-				"controller_runtime_reconcile_total",
-			))
-		})
-
 		It("should create a GardenerShootControlPlane with a hibernated Shoot", func(ctx SpecContext) {
 			By("create client")
 			clusterClient, err := kubernetes.NewClientFromFile("", os.Getenv("KUBECONFIG"),
@@ -267,9 +172,11 @@ var _ = Describe("Manager", Ordered, func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 
+			namePrefix := "e2e-kind-"
+
 			controlPlaneSpec := &controlplanev1alpha1.GardenerShootControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cp-e2e-",
+					GenerateName: namePrefix,
 					Namespace:    "default",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "cluster-api-provider-gardener",
@@ -292,7 +199,7 @@ var _ = Describe("Manager", Ordered, func() {
 
 			infraClusterSpec := &infrastructurev1alpha1.GardenerShootCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cp-e2e-",
+					GenerateName: namePrefix,
 					Namespace:    "default",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "cluster-api-provider-gardener",
@@ -416,62 +323,3 @@ var _ = Describe("Manager", Ordered, func() {
 		// ))
 	})
 })
-
-// serviceAccountToken returns a token for the specified service account in the given namespace.
-// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
-// and parsing the resulting token from the API response.
-func serviceAccountToken() (string, error) {
-	const tokenRequestRawString = `{
-		"apiVersion": "authentication.k8s.io/v1",
-		"kind": "TokenRequest"
-	}`
-
-	// Temporary file to store the token request
-	secretName := fmt.Sprintf("%s-token-request", serviceAccountName)
-	tokenRequestFile := filepath.Join("/tmp", secretName)
-	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
-	if err != nil {
-		return "", err
-	}
-
-	var out string
-	verifyTokenCreation := func(g Gomega) {
-		// Execute kubectl command to create the token
-		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
-			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
-			namespace,
-			serviceAccountName,
-		), "-f", tokenRequestFile)
-
-		output, err := cmd.CombinedOutput()
-		g.Expect(err).NotTo(HaveOccurred())
-
-		// Parse the JSON output to extract the token
-		var token tokenRequest
-		err = json.Unmarshal(output, &token)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		out = token.Status.Token
-	}
-	Eventually(verifyTokenCreation).Should(Succeed())
-
-	return out, err
-}
-
-// getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
-func getMetricsOutput() string {
-	By("getting the curl-metrics logs")
-	cmd := exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-	metricsOutput, err := utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-	Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
-	return metricsOutput
-}
-
-// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
-// containing only the token field that we need to extract.
-type tokenRequest struct {
-	Status struct {
-		Token string `json:"token"`
-	} `json:"status"`
-}

--- a/test/e2e/kind/e2e_test.go
+++ b/test/e2e/kind/e2e_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Manager", Ordered, Label("kind"), func() {
 			Eventually(verifyControllerUp).Should(Succeed())
 		})
 
-		It("should create a GardenerShootControlPlane with a hibernated Shoot", func(ctx SpecContext) {
+		It("should create a CAPI Cluster resulting in a hibernated Shoot", func(ctx SpecContext) {
 			By("create client")
 			clusterClient, err := kubernetes.NewClientFromFile("", os.Getenv("KUBECONFIG"),
 				kubernetes.WithClientOptions(client.Options{Scheme: api.Scheme}),

--- a/test/utils/kcp.go
+++ b/test/utils/kcp.go
@@ -15,7 +15,7 @@ func EnsureAndSwitchWorkspace(workspacePath ...string) error {
 	}
 	fmt.Printf("Current workspace: %q, expected workspace: %q\n", currentWorkspace, expectedWorkspacePath)
 	if strings.Contains(currentWorkspace, fmt.Sprintf("'%s'", expectedWorkspacePath)) {
-		return err
+		return nil
 	}
 	_, err = Run(exec.Command("kubectl", "kcp", "ws", ":root"))
 	if err != nil {

--- a/test/utils/kcp.go
+++ b/test/utils/kcp.go
@@ -21,7 +21,7 @@ func EnsureAndSwitchWorkspace(workspacePath ...string) error {
 	for _, path := range workspacePath {
 		_, err = Run(exec.Command("kubectl", "kcp", "ws", path)) // #nosec G204 -- only used during test
 		if err != nil {
-			_, err = Run(exec.Command("kubectl", "create workspace", path, "--enter")) // #nosec G204 -- only used during test
+			_, err = Run(exec.Command("kubectl", "create", "workspace", path, "--enter")) // #nosec G204 -- only used during test
 		}
 		if err != nil {
 			return err

--- a/test/utils/kcp.go
+++ b/test/utils/kcp.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// EnsureAndSwitchWorkspace ensures that the specified workspace exists in kcp, else creates it, and switches to it.
+func EnsureAndSwitchWorkspace(workspacePath ...string) error {
+	expectedWorkspacePath := "root:" + strings.Join(workspacePath, ":")
+	currentWorkspace, err := Run(exec.Command("kubectl", "kcp", "ws", "."))
+	fmt.Printf("Current workspace: %q, expected workspace: %q\n", currentWorkspace, expectedWorkspacePath)
+	if strings.Contains(currentWorkspace, fmt.Sprintf("'%s'", expectedWorkspacePath)) {
+		return err
+	}
+	_, err = Run(exec.Command("kubectl", "kcp", "ws", ":root"))
+	if err != nil {
+		return err
+	}
+	for _, path := range workspacePath {
+		_, err = Run(exec.Command("kubectl", "kcp", "ws", path))
+		if err != nil {
+			_, err = Run(exec.Command("kubectl", "create workspace", path, "--enter"))
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/utils/kcp.go
+++ b/test/utils/kcp.go
@@ -19,9 +19,9 @@ func EnsureAndSwitchWorkspace(workspacePath ...string) error {
 		return err
 	}
 	for _, path := range workspacePath {
-		_, err = Run(exec.Command("kubectl", "kcp", "ws", path))
+		_, err = Run(exec.Command("kubectl", "kcp", "ws", path)) // #nosec G204 -- only used during test
 		if err != nil {
-			_, err = Run(exec.Command("kubectl", "create workspace", path, "--enter"))
+			_, err = Run(exec.Command("kubectl", "create workspace", path, "--enter")) // #nosec G204 -- only used during test
 		}
 		if err != nil {
 			return err

--- a/test/utils/kcp.go
+++ b/test/utils/kcp.go
@@ -10,6 +10,9 @@ import (
 func EnsureAndSwitchWorkspace(workspacePath ...string) error {
 	expectedWorkspacePath := "root:" + strings.Join(workspacePath, ":")
 	currentWorkspace, err := Run(exec.Command("kubectl", "kcp", "ws", "."))
+	if err != nil {
+		return err
+	}
 	fmt.Printf("Current workspace: %q, expected workspace: %q\n", currentWorkspace, expectedWorkspacePath)
 	if strings.Contains(currentWorkspace, fmt.Sprintf("'%s'", expectedWorkspacePath)) {
 		return err

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -5,8 +5,6 @@
 package utils
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,10 +14,6 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.77.1"
-	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
-		"releases/download/%s/bundle.yaml"
-
 	certmanagerVersion = "v1.16.3"
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
@@ -46,50 +40,6 @@ func Run(cmd *exec.Cmd) (string, error) {
 	}
 
 	return string(output), nil
-}
-
-// InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
-func InstallPrometheusOperator() error {
-	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "create", "-f", url) // #nosec G204 -- only used during test
-	_, err := Run(cmd)
-	return err
-}
-
-// UninstallPrometheusOperator uninstalls the prometheus
-func UninstallPrometheusOperator() {
-	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url) // #nosec G204 -- only used during test
-	if _, err := Run(cmd); err != nil {
-		warnError(err)
-	}
-}
-
-// IsPrometheusCRDsInstalled checks if any Prometheus CRDs are installed
-// by verifying the existence of key CRDs related to Prometheus.
-func IsPrometheusCRDsInstalled() bool {
-	// List of common Prometheus CRDs
-	prometheusCRDs := []string{
-		"prometheuses.monitoring.coreos.com",
-		"prometheusrules.monitoring.coreos.com",
-		"prometheusagents.monitoring.coreos.com",
-	}
-
-	cmd := exec.Command("kubectl", "get", "crds", "-o", "custom-columns=NAME:.metadata.name")
-	output, err := Run(cmd)
-	if err != nil {
-		return false
-	}
-	crdList := GetNonEmptyLines(output)
-	for _, crd := range prometheusCRDs {
-		for _, line := range crdList {
-			if strings.Contains(line, crd) {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // UninstallCertManager uninstalls the cert manager
@@ -176,53 +126,4 @@ func GetProjectDir() (string, error) {
 	wd = strings.ReplaceAll(wd, "/test/e2e/kind-kcp", "")
 	wd = strings.ReplaceAll(wd, "/test/e2e/kind", "")
 	return wd, nil
-}
-
-// UncommentCode searches for target in the file and remove the comment prefix
-// of the target content. The target content may span multiple lines.
-func UncommentCode(filename, target, prefix string) error {
-	// false positive
-	// nolint:gosec
-	content, err := os.ReadFile(filename) // #nosec G304 -- only used during test
-	if err != nil {
-		return err
-	}
-	strContent := string(content)
-
-	idx := strings.Index(strContent, target)
-	if idx < 0 {
-		return fmt.Errorf("unable to find the code %s to be uncomment", target)
-	}
-
-	out := new(bytes.Buffer)
-	_, err = out.Write(content[:idx])
-	if err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(bytes.NewBufferString(target))
-	if !scanner.Scan() {
-		return nil
-	}
-	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
-		}
-		// Avoid writing a newline in case the previous line was the last in target.
-		if !scanner.Scan() {
-			break
-		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
-		}
-	}
-
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
-	}
-	// false positive
-	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644) // #nosec G306 -- only used during test
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -173,7 +173,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.ReplaceAll(wd, "/test/e2e", "")
+	wd = strings.ReplaceAll(wd, "/test/e2e/kind", "")
 	return wd, nil
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -173,6 +173,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
+	wd = strings.ReplaceAll(wd, "/test/e2e/kind-kcp", "")
 	wd = strings.ReplaceAll(wd, "/test/e2e/kind", "")
 	return wd, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing quality robustness dev-productivity
/kind test enhancement

**What this PR does / why we need it**:
Add new e2e test for kcp case. To make the setup more resilient to updates in later maintenance.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Added kcp e2e tests.
```
