### PR TITLE
Fix renovate config exclusions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,7 +56,6 @@ The following dependencies have been updated:\n\
     "github.com/beorn7/perks",
     "github.com/blang/semver/v4",
     "github.com/brunoga/deep",
-    "github.com/cenkalti/backoff/v4",
     "github.com/cespare/xxhash/v2",
     "github.com/coreos/go-semver",
     "github.com/coreos/go-systemd/v22",

--- a/docs/kcp/getting-started-locally.md
+++ b/docs/kcp/getting-started-locally.md
@@ -7,6 +7,7 @@
 - ☸️ kubectl version v1.11.3+.
 - 🌻 a local Gardener cluster
 - 🗂️ a KCP server (`KUBECONFIG` usually is located in `.kcp/admin.kubeconfig`, relative from where KCP is started)
+  - a local KCP server can also be acquired by using the command `make kcp-up`
 - 🔌 KCP's `kubectl` plugins
 
 ## To Deploy on the cluster 🚢


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind impediment

**What this PR does / why we need it**:
Currently, the `make check` command does not succeed, as there is a pending modification in the Renovate config.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
