### PR TITLE
docs: fix diagram alt text to show CAPI → Gardener Shoot translation

### DIFF
--- a/docs/capi/architecture.md
+++ b/docs/capi/architecture.md
@@ -34,4 +34,4 @@ The `Shoot` API is distributed over the different provider API resources (`Garde
 > 
 > In addition to that, we provide sample manifests in the [`examples`](../../config/samples) directory of this repository. ✨
 
-![Image of the translation between Gardener API and Gardener API](./translation.svg)
+![Image of the translation between CAPI resources and Gardener Shoot API](./translation.svg)


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind bug

**What this PR does / why we need it**:
Fixes incorrect diagram alt text that described a translation between "Gardener API and Gardener API" (same source and target). Now correctly describes the translation between CAPI resources and Gardener Shoot API.

**Which issue(s) this PR fixes**:
Fixes # (no issue filed, just documentation update)

**Special notes for your reviewer**:
Trivial alt text fix only. No functional changes.

**Release note**:
```other operator
Fixed diagram alt text to correctly describe CAPI to Gardener Shoot API mapping