### PR TITLE
[fix] Inverted nil check in ClusterController.SetupWithManager

### DIFF
--- a/internal/controller/cluster/cluster_controller.go
+++ b/internal/controller/cluster/cluster_controller.go
@@ -193,7 +193,7 @@ func ensureOwnerRef(ctx context.Context, c client.Client, obj metav1.Object, clu
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterController) SetupWithManager(mgr mcmanager.Manager) error {
-	if r.Manager != nil {
+	if r.Manager == nil {
 		r.Manager = mgr
 	}
 	return mcbuilder.ControllerManagedBy(mgr).


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind bug

**What this PR does / why we need it**:

Fixes an inverted nil check in `ClusterController.SetupWithManager`. It read `if r.Manager != nil`, meaning the manager was only set when it was already set. The correct logic in my opinion needs to be `if r.Manager == nil`, set it only when it's missing. With the wrong check, a controller built without a `Manager` keeps it nil and panics on the first `Reconcile` at `r.Manager.GetCluster(...)`.

The only caller in `main.go` already passes `Manager: mgr`, so this is currently harmless. The fix prevents a nil-pointer panic for any future caller that relies on `SetupWithManager` to set it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

One-line change (`!=` → `==`) so the manager is set when nil instead of when already set. The only caller (`main.go`, KCP path) passes `Manager` explicitly, so existing behavior is unaffected.

**Release note**:

```
NONE
```